### PR TITLE
Refactor RepoPeek into a command line tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # RepoPeek - Take a Sneak Peek at Repositories.
 
-RepoPeek is a python script to get details about a repository just from your terminal before cloning it. All the information are retrieved using the [GitHub API](http://developer.github.com/v3/repos/). 
+RepoPeek is a python script to get details about a repository without cloning it. All the information are retrieved using the [GitHub API](http://developer.github.com/v3/repos/). 
 
 Please Note: In this script API requests aren't using basic authentication or OAuth. Therefore the rate limit allows for up to 60 requests per hour. Unauthenticated requests are associated with the originating IP address, and not the user making requests. (You can use a VPN to overcome this situation.)
-
-![iaa1](https://user-images.githubusercontent.com/55880211/80363200-7d35a000-88a1-11ea-8afe-0e3f688eb180.gif)
 
 ## Features
 1. Basic information about the repository.
@@ -29,18 +27,6 @@ Please Note: In this script API requests aren't using basic authentication or OA
    - Clone URL
    
 5. Cloning repositories.
-
-### Git Installation
-```
-# clone the repo
-$ git clone https://github.com/sameera-madushan/RepoPeek.git
-
-# change the working directory to RepoPeek
-$ cd RepoPeek
-
-# install the requirements
-$ pip3 install -r requirements.txt
-```
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
-# RepoPeek - Take a Sneak Peek at Repositories.
+# RepoPeek - Take a Sneak Peek at Repositories
 
-RepoPeek is a python script to get details about a repository without cloning it. All the information are retrieved using the [GitHub API](http://developer.github.com/v3/repos/). 
+RepoPeek is a Python script to get details about a repository without cloning
+it. All the information are retrieved using the
+[GitHub API](http://developer.github.com/v3/repos/).
 
-Please Note: In this script API requests aren't using basic authentication or OAuth. Therefore the rate limit allows for up to 60 requests per hour. Unauthenticated requests are associated with the originating IP address, and not the user making requests. (You can use a VPN to overcome this situation.)
+Note: API requests made by this module aren't using basic authentication or
+OAuth. Therefore the rate limit allows for up to 60 requests per hour.
+Unauthenticated requests are associated with the originating IP address.
 
-## Features
+
+## Info Provided
+
 1. Basic information about the repository.
    - Repository Name
    - Default Branch
@@ -19,24 +25,34 @@ Please Note: In this script API requests aren't using basic authentication or OA
    - Watchers
    - Open Issues
    - Total Stars
-   
+
 4. URL's of the repository.
    - GIT URL
    - SSH URL
    - SVN URL
    - Clone URL
-   
-5. Cloning repositories.
+
+
+## Installation
+
+To install this script so that it is accessible via Python from anywhere, copy
+the script into a directory of your choice, and then add that directory to your
+`PYTHONPATH`
+
 
 ## Usage
 
 ```
-python repopeek.py
+python -m repopeek
 ```
 
+
 ### Support & Contributions
+
 - Please ⭐️ this repository if this project helped you!
 - Contributions of any kind welcome!
 
+
 ## License
+
 MIT ©[sameera-madushan](https://github.com/sameera-madushan)

--- a/repopeek.py
+++ b/repopeek.py
@@ -20,12 +20,10 @@ args = parser.parse_args()
 colorama.init(autoreset=True)
 
 
-def num_bytes_to_size_str(size_bytes: int) -> str:
-   if size_bytes == 0:
-       return "0 B"
-   size_name = ("B", "KiB", "MiB", "GiB", "TiB")
-   x = int(math.floor(math.log(size_bytes, 1024)))
-   return f"{round(size_bytes / (1024 ** x), 2)} {size_name[x]}"
+def num_kilobytes_to_size_str(size_bytes: int) -> str:
+    size_name = ("KiB", "MiB", "GiB", "TiB")
+    x = int(math.floor(math.log(size_bytes, 1024)))
+    return f"{size_bytes / (1024 ** x):.2f} {size_name[x]}"
 
 
 def get_languages(language_url: str) -> List[str]:
@@ -47,7 +45,7 @@ def print_info(repo_info: Dict[str, Any]) -> None:
     print(Fore.YELLOW + "--------------------------------------")
     print(f"Repository Name: {repo_info['name']}")
     print(f"Default Branch: {repo_info['default_branch']}")
-    print(f"Repository Size: {num_bytes_to_size_str(repo_info['size']//1024)}")
+    print(f"Repository Size: {num_kilobytes_to_size_str(repo_info['size'])}")
     print(f"Repository License: {get_license(repo_info['license'])}")
     print(f"Repository Description: {repo_info['description']}")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
+certifi==2020.4.5.1
+chardet==3.0.4
+colorama==0.4.3
+idna==2.9
 requests==2.23.0
-colorama==0.4.0
-GitPython==3.1.1
+urllib3==1.25.9


### PR DESCRIPTION
Please refer to the list of changes made in the commit message for 402cedb

One other change I forgot to mention: instead of validating the URL with a regex, the script now accepts any input, and will fail if the URL is invalid when it tries to access it through the API. This change means that there are no more errors thrown for valid URLs. To access the repository and organization names, the URL provided is represented as a `pathlib.Path` object. In all valid URLs the stem is the repository name, and the second last part of the path is the organization name.